### PR TITLE
Updated with VPNKit 6.9.0

### DIFF
--- a/ConsumerVPN/SDKInitializer/SDKInitializer.m
+++ b/ConsumerVPN/SDKInitializer/SDKInitializer.m
@@ -17,13 +17,6 @@
 
 @implementation SDKInitializer
 
-+ (NSString *)baseURL {
-    return @"https://api.wlvpn.com/v3/";
-}
-
-+ (NSArray<NSString *> *)backupURLs {
-    return @[];
-}
 
 #pragma mark - Init
 
@@ -56,8 +49,6 @@
 	NSURL *coreDataURL = [appSupportURL URLByAppendingPathComponent:@"DataStore.sqlite"];
     
     NSDictionary *apiAdapterOptions = @{
-        kV3BaseUrlKey:          [SDKInitializer baseURL],
-        kV3AlternateUrlsKey:    [SDKInitializer backupURLs],
         kV3ApiKey:              apiKey,
         kV3CoreDataURL:         coreDataURL,
         kV3ServiceNameKey:      brandName
@@ -80,8 +71,6 @@
         kVPNHelperDisableIPSec:             [NSNumber numberWithBool:YES],
         kVPNApplicationSupportDirectoryKey: applicationSupportDirectory,
         kIKEv2KeychainServiceName:          apiAdapter.passwordServiceName,
-        kIKEv2V3BaseUrlKey:                 [SDKInitializer baseURL],
-        kIKEv2V3AlternateUrlsKey:           [SDKInitializer backupURLs],
     };
     
     // Create adapters
@@ -116,8 +105,6 @@
 		kVPNDefaultProtocolKey: defaultProtocol,
 		kCityPOPHostname:       @"wlvpn.com",
 		kBundleNameKey:         brandName,
-        kV3BaseUrlKey:          [SDKInitializer baseURL],
-        kV3AlternateUrlsKey:    [SDKInitializer backupURLs],
 	};
     
     VPNAPIManager *apiManager = [[VPNAPIManager alloc]
@@ -139,9 +126,7 @@
                                               kIKEv2Hostname: @"vpn.wlvpn.com",
                                       kIKEv2RemoteIdentifier: @"vpn.wlvpn.com",
                                          kVPNSharedSecretKey: @"vpn",
-                                   kIKEv2KeychainServiceName: keychainService,
-                                          kIKEv2V3BaseUrlKey: [SDKInitializer baseURL],
-                                         kIKEv2V3AlternateUrlsKey: [SDKInitializer backupURLs]};
+                                   kIKEv2KeychainServiceName: keychainService};
     
     return [[NEVPNManagerAdapter alloc] initWithOptions:connectionOptions];
 }
@@ -157,15 +142,8 @@
     wgConfig.useAPIKey = NO;
     wgConfig.uuid = uuid;
     wgConfig.extensionName = [NSString stringWithFormat:@"%@.network-extension", bundleIdentifier];
-    wgConfig.apiURL = [NSString stringWithFormat:@"%@wireguard", [SDKInitializer baseURL]];
     wgConfig.apiKey = apiKey;
-    
-    NSMutableArray *alternateURLs = [NSMutableArray new];
-    for (NSString *alternateURL in [SDKInitializer backupURLs]) {
-        [alternateURLs addObject:[NSString stringWithFormat:@"%@wireguard", alternateURL]];
-    }
-    wgConfig.backupURL = alternateURLs;
-    
+
     return [[WireGuardAdapter alloc] initWithConfiguration:wgConfig];
 }
 

--- a/SDK/README MacOS.md
+++ b/SDK/README MacOS.md
@@ -2,88 +2,85 @@
 
 VPNKit is the API and connection SDK for the WLVPN platform.
 
-## Dependencies
-
-The application has no external dependencies. It includes a copy of CocoaLumberjack for logging purposes. You can use
-this copy of CocoaLumberjack in your own application.
-
-
-## Minimum Requirements
-
- - iOS 14.0, macOS Mojave 10.14
- - API key access token
- Supports iPhone, iPad, Mac
-
-See: [Get Started](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/Get%20Started.md)
+# Table of contents
+1. [Dependencies](#dependencies)
+2. [Minimum Requirements](#minimum-requirements)
+3. [Project Setup](#project-setup)
+    1. [Add the required permissions for the app](#add-the-required-permissions-for-the-app)
+4. [Initialize the app](#initialize-the-app)
+    1. [VPNConfiguration](#vpnConfiguration)
+    2. [VPNAPIManager](#vpnapimanager)
+    3. [Adapters](#adapters)
+5. [Notifications](#notifications)
 
 
-## Project Setup
-
-The VPNKit framework needs to be linked into your project. You will also need to link at least one API adapter. The API adapter is linked as a static library while the framework is included and embedded in the project. 
-
-The framework is a "fat" binary, which should work in both the simulator and on a device.
-
-## Add the required permissions for the app
-
-See: [VPNKit macOS Guide](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/VPNKit%20macOS%20Guide.md)
+# Dependencies
+The application has no external dependencies. It includes a copy of CocoaLumberjack for logging purposes. You can use this copy of CocoaLumberjack in your own application.
 
 
-## Notifications
+# Minimum Requirements
+##### Operating Systems
+- iOS    13.0 +
+- iPadOS 13.0 +
+- macOS  10.15 +
+- tvOS   17.0 +
 
-The framework uses`NSNotification` and `NSNotificationCenter` to handle asynchronous actions. You call a framework 
-function and it will perform asynchronous actions. At various points during the action, a notification will be sent 
-out that allows your client to respond to the event. 
+##### Access
+- API key and suffix, provided by your WLVPN representative.
 
-### Example events:
-
-```
-VPNConnectionWillBeginNotification
-VPNConnectionSucceededNotification
-VPNServerUpdateWillBeginNotification
-VPNServerUpdateSucceededNotification
-```
-
-See: [Notifications Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/Notifications.md)
-
-
-## Primary Objects
-
-### VPNConfiguration
-
-The VPNConfiguration represents the current state of the VPN framework. It contains objects like user credentials, their account information, current selected city/country/server, and specific configuration
-options. You can monitor for changes in this class using either KVO or NotificationCenter. Each property
-will fire off a notification both before and after it changes internally. The VPNConfiguration is a singleton and can be accessed in the "vpnConfiguration" property of VPNAPIManager. You should not hold a separate reference to the VPNConfiguration. You should access it from the VPNAPIManager.
-
-See: [VPNConfiguration Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/VPNConfiguration.md)
+##### Supported OS
+- iOS
+- iPadOS
+- macOS
+- tvOS
 
 
-### VPNAPIManager
+# Project Setup
+1. Copy the VPNKit SDKs (VPNKit, VPNV3APIAdapter) from macOS or XCFrameworks to the SDK folder of the project.
+    
+2. Copy the VPNKitNetworkExtensionAdapters SDKs (VPKWireGuardAdapter, VPKWireGuardExtension) from macOS or XCFrameworks to the SDK folder of the project.
 
-The VPNAPIManager is the primary object you will use to interact with VPNKit. It will perform all its actions using the attached VPNConfiguration. The VPNAPIAdapter manages its own Core Data store; it should not conflict with any store you have in your application. 
+- You can find the VPNKit changelog in its subfolder.
 
-See: [VPNAPIManager Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/APIManager.md)
+> Refer to: [Changelog](../Documentation/Changelog.md)
 
+##### Add the required permissions for the app
 
-#### Adapters
+Add the required permissions for the app in the ***project file*** and initialize the app using the
+[Primary Objects](#primary-objects).
 
-There are two types of adapters in VPNKit: Connection adapters and API adapters. 
-
-An API adapter is used to connect to an API. The only adapter you will need to worry about is the V3APIAdapter. This connects to the current version of the VPN backend and will handle retrieval of API resources.
-
-A connection adapter is used to connect to specific VPN protocols. The main adapter usable on macOS and iOS is the NEVPNManagerAdapter. This adapter interfaces with the Apple provided NEVPNManager interface to provide system supported VPN connections. It supports IKEv2 and IPSec based connections. Due to limitations with iOS, this is the only adapter we support on iOS. The simulator for iOS does not support VPN connections. On the simulator, we simulate connections with the VPNConnectionTestAdapter. This can also be used to support UI tests in the iOS simulator. 
-
-On macOS, we support OpenVPN and L2TP, but these require a privileged helper tool and will require specific assistance from us. 
-
-See: [Adapters Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/Adapters.md)
+> Refer: [VPNKit macOS Guide](../Documentation/VPNKit%20macOS%20Guide.md) 
 
 
-#### VPNAPIInitializer
+# Initialize the app
+Initialize the app with the provided `APIKey`, `suffix` and `brandName`, `configName`
 
-The framework is best initialized using Objective-C. 
-
-See: [VPNAPIInitializer Documentation](https://github.com/wlvpn/ConsumerVPN-iOS/blob/main/SDK/VPNKit%20SDK%20Documentation/Initializers.md)
+> Refer: [Initializers](../Documentation/Initializers.md)
 
 
-To get the necessary assets/SDK, please contact support@wlvpn.com
+### Primary Objects
 
+##### VPNConfiguration
+The `VPNConfiguration` represents the current state of the VPN framework. It contains objects like user credentials, their account information, current selected city/country/server, and specific configuration options. You can monitor for changes in this class using either KVO or NotificationCenter. Each property will fire off a notification both before and after it changes internally. The `VPNConfiguration` is a singleton and can be accessed in the "vpnConfiguration" property of `VPNAPIManager`. You should not hold a separate reference to the VPNConfiguration. You should access it from the VPNAPIManager.
+
+> Refer: [VPNConfiguration](../Documentation/VPNConfiguration.md)
+
+##### VPNAPIManager
+The `VPNAPIManager` is the primary object you will use to interact with VPNKit. It will perform all its actions using the attached VPNConfiguration. The `VPNAPIAdapter` manages its own Core Data store; it should not conflict with any store you have in your application.
  
+> Refer: [APIManager](../Documentation/APIManager.md)
+
+##### Adapters
+There are two types of adapters in VPNKit: `Connection Adapters` and `API Adapters`.
+An API Adapter is used to connect to an API. The only adapter you will need to worry about is the V3APIAdapter. This connects to the current version of the VPN backend and will handle retrieval of API resources. 
+A Connection Adapter is used to connect to specific VPN protocols. The main adapter usable on iOS, macOS and tvOS is the `NEVPNManagerAdapter`. This adapter interfaces with the Apple provided NEVPNManager interface, to provide system supported VPN connections. It supports IKEv2 and IPSec based connections. Due to limitations with iOS, this is the only adapter we support on iOS. The simulator for iOS does not support VPN connections. On the simulator, we simulate connections with the VPNConnectionTestAdapter. This can also be used to support UI tests in the iOS simulator. On macOS, we support OpenVPN but this require a privileged helper tool and will require specific assistance from us.
+ 
+> Refer: [Adapters](../Documentation/Adapters.md)
+
+
+# Notifications
+You call a framework function and it will perform asynchronous actions. At various points during the action, a notification will be sent out that allows you to respond to the event. 
+> Refer: [Notifications](../Documentation/Notifications.md)
+
+
+> To get the necessary assets/SDK, please contact support@wlvpn.com


### PR DESCRIPTION
- Moved documentation inside SDK folder 
- Base URL and API mirrors no longer needed to provide by client.