### PR TITLE
Security: Fix macOS privilege escalation in OpenVPN helper

### DIFF
--- a/ConsumerVPN/Controllers/Window/MainWindowController.swift
+++ b/ConsumerVPN/Controllers/Window/MainWindowController.swift
@@ -453,8 +453,16 @@ extension MainWindowController : VPNConnectionStatusReporting {
             displayAlert(informativeText: "Connection Failed",
                          messageText: "Please check your internet connection.")
         } else {
-            displayAlert(informativeText: "Connection Failed",
-                         messageText: (notification.object as? NSError)?.localizedDescription ?? "Unknown")
+            if let errorCode = (notification.object as? NSError)?.code, (errorCode == VPNKitConfigurationRuntimeError.serverUnhealthyError.rawValue || errorCode == VPNKitConfigurationRuntimeError.invalidServerError.rawValue) {
+                let title = NSLocalizedString("ErrorConnectingVpn", comment: "Connection error title")
+                let message = String(format:  NSLocalizedString("UnhealthyServer", comment: "Connection error message"), String(errorCode))
+                displayAlert(informativeText: title,
+                             messageText: message)
+            }
+            else {
+                displayAlert(informativeText: "Connection Failed",
+                             messageText: (notification.object as? NSError)?.localizedDescription ?? "Unknown")
+            }
         }
         
         updateAppliedViewForDisconnectOrFailure()
@@ -535,6 +543,10 @@ extension MainWindowController : VPNConnectionStatusReporting {
     func updateConfigurationFailed(_ notification: Notification) {
         connectView.toggleUIForEnabledState(isEnabled: true)
         connectView.vpnConnectButton.buttonText = NSLocalizedString("Connect", comment: "Connect")
+        if let error = notification.object as? NSError {
+            displayAlert(informativeText: "Configuration Failed",
+                         messageText: error.localizedDescription)
+        }
     }
     
     //MARK: - VPN Health Check

--- a/ConsumerVPN/README.md
+++ b/ConsumerVPN/README.md
@@ -6,7 +6,7 @@
 ![Supports ARM](https://img.shields.io/badge/ARM-arm64-informational)
 ![Supports Intel](https://img.shields.io/badge/Intel-x86_64-informational)
 ![XCFramework Included](https://img.shields.io/badge/XCFramework-included-success)
-[![VPNKit 7.1.1](https://img.shields.io/badge/VPNKit-7.1.1-brightgreen)](https://github.com/wlvpn/ConsumerVPN-macOS/blob/main/SDK/Documentation/README.md)
+[![VPNKit 7.1.2](https://img.shields.io/badge/VPNKit-7.1.2-brightgreen)](https://github.com/wlvpn/ConsumerVPN-macOS/blob/main/SDK/Documentation/README.md)
 
 ConsumerVPN is a ready-to-brand application built with Swift and the WLVPN VPN SDK. It provides a foundation for your own VPN app and serves as a complete guide for integrating the WLVPN VPN SDK.(VPNKit).
 

--- a/ConsumerVPN/Resources/en.lproj/Localizable.strings
+++ b/ConsumerVPN/Resources/en.lproj/Localizable.strings
@@ -58,6 +58,8 @@
 "OnDemandConfirm" = "Disconnecting from the VPN will disable On Demand. Do you wish to continue?";
 "DisableOnDemandDisconnect" = "Disabling On Demand will disconnect you from the VPN. Would you like to continue?";
 "EnableOnDemandDisconnect" = "Enabling On Demand will temporarily disconnect you from the VPN. Would you like to continue?";
+"ErrorConnectingVpn" = "Error connecting to the VPN";
+"UnhealthyServer" = "Please try again or select a different location.\n(Code: %@)";
 
 /* Filter View Strings */
 "ResetFilters" = "Reset";

--- a/ConsumerVPN/Resources/es.lproj/Localizable.strings
+++ b/ConsumerVPN/Resources/es.lproj/Localizable.strings
@@ -59,6 +59,8 @@
 "OnDemandConfirm" = "Desconectarse de la VPN deshabilitará la configuración de Bajo Demanda. ¿Deseas continuar?";
 "DisableOnDemandDisconnect" = "Deshabilitar Bajo Demanda te desconectará de la VPN. ¿Te gustaria continuar?";
 "EnableOnDemandDisconnect" = "Habilitar On Demand lo desconectará temporalmente de la VPN.. ¿Te gustaria continuar?";
+"ErrorConnectingVpn" = "Error al conectar con la VPN";
+"UnhealthyServer" = "Inténtalo de nuevo o selecciona otra ubicación.\n(Código: %@)";
 
 /* Filter View Strings */
 "ResetFilters" = "Reiniciar";

--- a/SDK/Documentation/Changelog.md
+++ b/SDK/Documentation/Changelog.md
@@ -1,5 +1,10 @@
 # VPNKit Changelog
 
+## VPNKit 7.1.2
+
+### Improvements
+**Security:** Fixed a macOS privilege escalation vulnerability in the OpenVPN command-line helper where insufficient validation could allow unauthorized executables to interact with the privileged helper. The SDK now enforces certificate validation and code-signing checks. Integrators must update the OpenVPN CLI tool to ensure the helper is properly updated on user systems.
+
 ## VPNKit 7.1.1
 
 ### Improvements

--- a/SDK/Documentation/README.md
+++ b/SDK/Documentation/README.md
@@ -1,6 +1,6 @@
 # VPNKit Version
 ------
-The latest version of the WLVPN Apple SDK is 7.1.1
+The latest version of the WLVPN Apple SDK is 7.1.2
 
 ## Getting started
 

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -9,5 +9,5 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-MARKETING_VERSION = 7.1.1
+MARKETING_VERSION = 7.1.2
 CURRENT_PROJECT_VERSION = 1


### PR DESCRIPTION
- Update the application with the latest VPNKit v7.1.2. 
- Ensure the OpenVPN Command Line Tool Build version is updated to reflect the changes in the user’s system.